### PR TITLE
0.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install and test
+        run: |
+          yarn
+          yarn test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solandra",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": "James Porter <james@amimetic.co.uk>",
   "private": true,
   "description": "A framework for algorithmic art. TypeScript first. Make drawing concepts part of framework. Make APIs for humans.",

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,22 @@
+import Document, { Html, Head, Main, NextScript } from "next/document"
+
+class MyDocument extends Document {
+  render() {
+    return (
+      <Html>
+        <Head>
+          <link
+            href="https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@600&display=swap"
+            rel="stylesheet"
+          />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default MyDocument

--- a/pages/text.tsx
+++ b/pages/text.tsx
@@ -1,0 +1,5 @@
+import { Main } from "../src/views/Main"
+
+const MainPage = () => <Main category="Text" />
+
+export default MainPage

--- a/pages/view.tsx
+++ b/pages/view.tsx
@@ -14,6 +14,7 @@ import {
 import SyntaxHighlighter from "react-syntax-highlighter"
 import { Canvas } from "../src/components/Canvas"
 import source from "../src/data/source.json"
+import Head from "next/head"
 
 export const INDEX_KEY = "play-ts.index"
 export const SEED_KEY = "play-ts.seed"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -31,11 +31,13 @@ export default function Header() {
 
         if (isMatch) {
           return (
-            <div className="text-amber-200 font-bold  p-4">{link.name}</div>
+            <div className="text-amber-200 font-bold  p-4" key={i}>
+              {link.name}
+            </div>
           )
         } else {
           return (
-            <Link href={link.href}>
+            <Link href={link.href} key={i}>
               <a className="text-white font-bold hover:text-rose-200 p-4">
                 {link.name}
               </a>

--- a/src/examples/api-samples.ts
+++ b/src/examples/api-samples.ts
@@ -323,7 +323,6 @@ const helloWorld = (p: SCanvas) => {
           {
             at: [n * aspectRatio, n],
             size: 0.2,
-            sizing: "fixed",
             align,
             weight: "600",
           },
@@ -336,7 +335,6 @@ const helloWorld = (p: SCanvas) => {
         {
           at: [n * aspectRatio, n],
           size: 0.2,
-          sizing: "fixed",
           align: "center",
           weight: "600",
         },

--- a/src/examples/sketches.ts
+++ b/src/examples/sketches.ts
@@ -5,6 +5,7 @@ import samples from "./api-samples"
 import highlights from "./highlights"
 import isometric from "./isometric"
 import randomness from "./randomness"
+import text from "./text"
 
 const sketches = {
   Highlights: {
@@ -50,6 +51,12 @@ framework. Click on Source Code to see how things work.`,
     fileName: "randomness.ts",
     path: "/randomness-and-noise",
     description: `Examples focusing on randomness or noise. Click on Source Code to see how things work.`,
+  },
+  Text: {
+    sketches: text,
+    fileName: "text.ts",
+    path: "/text",
+    description: `Examples of text APIs`,
   },
 }
 

--- a/src/examples/text.ts
+++ b/src/examples/text.ts
@@ -1,4 +1,4 @@
-import { SCanvas } from "../lib"
+import { SCanvas, v } from "../lib"
 
 const textSketches: { name: string; sketch: (p: SCanvas) => void }[] = [
   {
@@ -55,6 +55,27 @@ const textSketches: { name: string; sketch: (p: SCanvas) => void }[] = [
       )
     },
     name: "Measure",
+  },
+  {
+    sketch: (s) => {
+      s.background(40, 40, 90)
+      s.setFillColor(340, 80, 30)
+      s.fillText(
+        { at: s.meta.center, size: 0.17, font: "Josefin Sans" },
+        `Josefin Sans`
+      )
+
+      s.setFillColor(210, 80, 30)
+      s.fillText(
+        {
+          at: v.add(s.meta.center, [0, 0.2]),
+          size: 0.1,
+          font: "Josefin Sans",
+        },
+        `A web font`
+      )
+    },
+    name: "Web Font",
   },
 ]
 

--- a/src/examples/text.ts
+++ b/src/examples/text.ts
@@ -16,14 +16,45 @@ const textSketches: { name: string; sketch: (p: SCanvas) => void }[] = [
         },
         "Hi there!"
       )
-
-      // @ts-ignore
-      // const ctx: CanvasRenderingContext2D = s.ctx
-      // // this doesn't work on safari ...
-      // ctx.font = "0.5px sans-serif"
-      // ctx.fillText("test", 0, 0.5)
     },
     name: "Basics",
+  },
+  {
+    sketch: (s) => {
+      s.background(50, 30, 90)
+
+      s.setFillColor(110, 80, 30)
+
+      s.times(11, (i) => {
+        s.times(11, (j) => {
+          s.fillText(
+            {
+              at: [i / 10, j / 10],
+              size: 0.015,
+              align: "center",
+              font: "times",
+            },
+            `${i / 10},${j / 10}`
+          )
+        })
+      })
+    },
+    name: "Position",
+  },
+  {
+    sketch: (s) => {
+      s.background(220, 30, 90)
+
+      s.setFillColor(310, 80, 30)
+
+      const m = s.measureText({ size: 0.2, font: "sans" }, "Hi there!")
+
+      s.fillText(
+        { at: s.meta.center, size: 0.1, font: "sans" },
+        `w: ${m.width.toFixed(2)} bba: ${m.fontBoundingBoxAscent}`
+      )
+    },
+    name: "Measure",
   },
 ]
 

--- a/src/examples/text.ts
+++ b/src/examples/text.ts
@@ -6,21 +6,22 @@ const textSketches: { name: string; sketch: (p: SCanvas) => void }[] = [
       s.background(210, 90, 80)
 
       s.setFillColor(210, 80, 30)
-      //   s.fillText(
-      //     {
-      //       at: s.meta.center,
-      //       size: 0.2,
-      //       align: "center",
-      //       font: "sans-serif",
-      //     },
-      //     "Hi there!"
-      //   )
+
+      s.fillText(
+        {
+          at: s.meta.center,
+          size: 0.19999,
+          align: "center",
+          font: "sans-serif",
+        },
+        "Hi there!"
+      )
 
       // @ts-ignore
-      const ctx: CanvasRenderingContext2D = s.ctx
-      // this doesn't work on safari ...
-      ctx.font = "0.49px sans-serif"
-      ctx.fillText("test", 0, 1)
+      // const ctx: CanvasRenderingContext2D = s.ctx
+      // // this doesn't work on safari ...
+      // ctx.font = "0.5px sans-serif"
+      // ctx.fillText("test", 0, 0.5)
     },
     name: "Basics",
   },

--- a/src/examples/text.ts
+++ b/src/examples/text.ts
@@ -1,0 +1,29 @@
+import { SCanvas } from "../lib"
+
+const textSketches: { name: string; sketch: (p: SCanvas) => void }[] = [
+  {
+    sketch: (s) => {
+      s.background(210, 90, 80)
+
+      s.setFillColor(210, 80, 30)
+      //   s.fillText(
+      //     {
+      //       at: s.meta.center,
+      //       size: 0.2,
+      //       align: "center",
+      //       font: "sans-serif",
+      //     },
+      //     "Hi there!"
+      //   )
+
+      // @ts-ignore
+      const ctx: CanvasRenderingContext2D = s.ctx
+      // this doesn't work on safari ...
+      ctx.font = "0.49px sans-serif"
+      ctx.fillText("test", 0, 1)
+    },
+    name: "Basics",
+  },
+]
+
+export default textSketches

--- a/src/lib/paths/Text.ts
+++ b/src/lib/paths/Text.ts
@@ -19,25 +19,12 @@ export type FontWeight =
   | "700"
   | "800"
   | "900"
-export enum Font {
-  Arial = "Arial",
-  Helvetica = "Helvetica",
-  TimesNewRoman = "Times New Roman",
-  Times = "Times",
-  CourierNew = "Courier New",
-  Courier = "Courier",
-  Palatino = "Palatino",
-  Garamond = "Garamond",
-  Bookman = "Bookman",
-  AvantGarde = "Avant Garde",
-  System = "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica, Arial, sans-serif",
-}
 
 export type TextConfigWithKind = {
   sizing?: TextSizing
   align?: TextHorizontalAlign
   size: number
-  font?: Font
+  font?: string
   at: Point2D
   kind: "fill" | "stroke"
   style?: FontStyle
@@ -46,6 +33,9 @@ export type TextConfigWithKind = {
 }
 
 export type TextConfig = Omit<TextConfigWithKind, "kind">
+
+export const systemFont =
+  "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica, Arial, sans-serif"
 
 export class Text implements Textable {
   /**
@@ -60,7 +50,7 @@ export class Text implements Textable {
       size,
       sizing = "fixed",
       align = "center",
-      font = Font.System,
+      font = systemFont,
       at,
       style = "normal",
       weight = "normal",

--- a/src/lib/paths/Text.ts
+++ b/src/lib/paths/Text.ts
@@ -82,4 +82,31 @@ export class Text {
       }
     }
   }
+
+  measure(ctx: CanvasRenderingContext2D): TextMetrics {
+    const { size, align = "center" } = this.config
+    ctx.textAlign = align
+
+    // Safari messes up for small sizes
+    if (size < 1) {
+      ctx.font = configToFontSpecString({
+        ...this.config,
+        size: this.config.size * 100,
+      })
+
+      const m = ctx.measureText(this.text)
+      return {
+        actualBoundingBoxAscent: m.actualBoundingBoxAscent / 100,
+        actualBoundingBoxDescent: m.actualBoundingBoxDescent / 100,
+        actualBoundingBoxLeft: m.actualBoundingBoxLeft / 100,
+        actualBoundingBoxRight: m.actualBoundingBoxRight / 100,
+        fontBoundingBoxAscent: m.fontBoundingBoxAscent / 100,
+        fontBoundingBoxDescent: m.fontBoundingBoxDescent / 100,
+        width: m.width / 100,
+      }
+    } else {
+      ctx.font = configToFontSpecString(this.config)
+      return ctx.measureText(this.text)
+    }
+  }
 }

--- a/src/lib/paths/index.ts
+++ b/src/lib/paths/index.ts
@@ -1,7 +1,3 @@
 export interface Traceable {
   traceIn(ctx: CanvasRenderingContext2D): void
 }
-
-export interface Textable {
-  textIn(ctx: CanvasRenderingContext2D): void
-}

--- a/src/lib/sCanvas.ts
+++ b/src/lib/sCanvas.ts
@@ -221,11 +221,11 @@ export default class SCanvas {
   }
 
   drawText(config: TextConfig, text: string) {
-    new Text({ ...config, kind: "stroke" }, text).textIn(this.ctx)
+    new Text({ ...config, kind: "stroke" }, text).textIn(this.ctx, this)
   }
 
   fillText(config: TextConfig, text: string) {
-    new Text({ ...config, kind: "fill" }, text).textIn(this.ctx)
+    new Text({ ...config, kind: "fill" }, text).textIn(this.ctx, this)
   }
 
   forMargin = (

--- a/src/lib/sCanvas.ts
+++ b/src/lib/sCanvas.ts
@@ -228,6 +228,12 @@ export default class SCanvas {
     new Text({ ...config, kind: "fill" }, text).textIn(this.ctx, this)
   }
 
+  measureText(config: Omit<TextConfig, "at">, text: string) {
+    return new Text({ ...config, kind: "stroke", at: [0, 0] }, text).measure(
+      this.ctx
+    )
+  }
+
   forMargin = (
     margin: number,
     callback: (

--- a/src/lib/sCanvas.ts
+++ b/src/lib/sCanvas.ts
@@ -550,17 +550,17 @@ export default class SCanvas {
   withTransform = (
     config: {
       hScale: number
-      hskew: number
+      hSkew: number
       vSkew: number
-      vScaling: number
+      vScale: number
       dX: number
       dY: number
     },
     callback: () => void
   ) => {
     this.pushState()
-    const { hScale, hskew, vSkew, vScaling, dX, dY } = config
-    this.ctx.transform(hScale, hskew, vSkew, vScaling, dX, dY)
+    const { hScale, hSkew, vSkew, vScale, dX, dY } = config
+    this.ctx.transform(hScale, hSkew, vSkew, vScale, dX, dY)
     callback()
     this.popState()
   }


### PR DESCRIPTION
Goals/notes: tidy up some apis, want to improve text stuff; seeing some major issues with that on safari (as solandra uses small sizes and safari seems to mess up the font rendering then; expect I can get round this with some scaling?)

- [x] bump version
- [x] fix naming in api
- [x] make the font argument a string, didn't make sense to lock down
- [x] figure out how to render fractional font sizes etc on safari
- [x] figure out text measurement weirdness/difference on safari
- [x] add examples for text stuff