### PR TITLE
Add comprehensive test coverage for core library modules

### DIFF
--- a/src/lib/__tests__/collectionOps.test.ts
+++ b/src/lib/__tests__/collectionOps.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { pairWise, tripleWise } from "../collectionOps";
+import { pairWise, tripleWise, zip2, sum, arrayOf } from "../collectionOps";
 
 describe("Pairwise", () => {
   it("should be able to do pairwise on simple array", () => {
@@ -8,6 +8,14 @@ describe("Pairwise", () => {
 
   it("should give empty array when not long enough", () => {
     expect(pairWise([1])).toEqual([]);
+  });
+
+  it("should handle exactly two elements", () => {
+    expect(pairWise([1, 2])).toEqual([[1, 2]]);
+  });
+
+  it("should handle empty array", () => {
+    expect(pairWise([])).toEqual([]);
   });
 });
 
@@ -19,17 +27,119 @@ describe("Triplewise", () => {
   it("should give empty array when not long enough", () => {
     expect(tripleWise([1, 2])).toEqual([]);
   });
+
+  it("should handle exactly three elements", () => {
+    expect(tripleWise([1, 2, 3])).toEqual([[1, 2, 3]]);
+  });
+
+  it("should handle looped mode", () => {
+    const result = tripleWise([1, 2, 3, 4], true);
+    // For looped mode, it should wrap around
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).toContainEqual([1, 2, 3]);
+    expect(result).toContainEqual([2, 3, 4]);
+  });
+
+  it("should handle empty array", () => {
+    expect(tripleWise([])).toEqual([]);
+  });
 });
 
-// TODO add back into main tests
-// describe("Shuffle", () => {
-//   it("should have same elements", () => {
-//     const samples = [[1, 2, 3, 4, 6, 9], [1], [1, 2, 3, 4, 6, 9, 12, 21, -2]];
+describe("zip2", () => {
+  it("should zip two arrays of equal length", () => {
+    expect(zip2([1, 2, 3], ["a", "b", "c"])).toEqual([
+      [1, "a"],
+      [2, "b"],
+      [3, "c"],
+    ]);
+  });
 
-//     for (let sample of samples) {
-//       expect([...new Set(shuffle(sample))].sort()).toEqual(
-//         [...new Set(sample)].sort()
-//       );
-//     }
-//   });
-// });
+  it("should stop at shorter array (first shorter)", () => {
+    expect(zip2([1, 2], ["a", "b", "c", "d"])).toEqual([
+      [1, "a"],
+      [2, "b"],
+    ]);
+  });
+
+  it("should stop at shorter array (second shorter)", () => {
+    expect(zip2([1, 2, 3, 4], ["a", "b"])).toEqual([
+      [1, "a"],
+      [2, "b"],
+    ]);
+  });
+
+  it("should handle empty arrays", () => {
+    expect(zip2([], [])).toEqual([]);
+    expect(zip2([1, 2], [])).toEqual([]);
+    expect(zip2([], ["a", "b"])).toEqual([]);
+  });
+
+  it("should work with different types", () => {
+    expect(zip2([1, 2], [true, false])).toEqual([
+      [1, true],
+      [2, false],
+    ]);
+  });
+
+  it("should work with single elements", () => {
+    expect(zip2([1], ["a"])).toEqual([[1, "a"]]);
+  });
+});
+
+describe("sum", () => {
+  it("should sum an array of numbers", () => {
+    expect(sum([1, 2, 3, 4])).toBe(10);
+  });
+
+  it("should return 0 for empty array", () => {
+    expect(sum([])).toBe(0);
+  });
+
+  it("should handle single element", () => {
+    expect(sum([5])).toBe(5);
+  });
+
+  it("should handle negative numbers", () => {
+    expect(sum([1, -2, 3, -4])).toBe(-2);
+  });
+
+  it("should handle decimals", () => {
+    expect(sum([0.1, 0.2, 0.3])).toBeCloseTo(0.6);
+  });
+
+  it("should handle all zeros", () => {
+    expect(sum([0, 0, 0])).toBe(0);
+  });
+});
+
+describe("arrayOf", () => {
+  it("should create an array of specified length", () => {
+    const result = arrayOf(5, () => 0);
+    expect(result).toHaveLength(5);
+    expect(result).toEqual([0, 0, 0, 0, 0]);
+  });
+
+  it("should call init function for each element", () => {
+    let count = 0;
+    const result = arrayOf(3, () => count++);
+    expect(result).toEqual([0, 1, 2]);
+  });
+
+  it("should handle zero length", () => {
+    expect(arrayOf(0, () => 1)).toEqual([]);
+  });
+
+  it("should create distinct objects", () => {
+    const result = arrayOf(3, () => ({ x: 0 }));
+    result[0].x = 1;
+    expect(result[1].x).toBe(0); // Should be distinct objects
+  });
+
+  it("should work with complex types", () => {
+    const result = arrayOf(2, () => [1, 2]);
+    expect(result).toEqual([[1, 2], [1, 2]]);
+    // Verify they are distinct arrays
+    result[0].push(3);
+    expect(result[1]).toEqual([1, 2]);
+  });
+});

--- a/src/lib/__tests__/colors.test.ts
+++ b/src/lib/__tests__/colors.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest"
+import {
+  hsla,
+  simpleLinearGradient,
+  hueRange,
+  saturationRange,
+  lightnessRange,
+  alphaRange,
+} from "../colors"
+
+describe("colors", () => {
+  describe("hsla", () => {
+    it("creates an HSLA color string with default alpha", () => {
+      expect(hsla(0, 100, 50)).toBe("hsla(0, 100%, 50%, 1)")
+    })
+
+    it("creates an HSLA color string with custom alpha", () => {
+      expect(hsla(240, 100, 50, 0.5)).toBe("hsla(240, 100%, 50%, 0.5)")
+    })
+
+    it("handles full hue range", () => {
+      expect(hsla(360, 100, 50)).toBe("hsla(360, 100%, 50%, 1)")
+    })
+
+    it("handles zero values", () => {
+      expect(hsla(0, 0, 0, 0)).toBe("hsla(0, 0%, 0%, 0)")
+    })
+
+    it("handles decimal values", () => {
+      expect(hsla(180.5, 75.5, 25.5, 0.75)).toBe("hsla(180.5, 75.5%, 25.5%, 0.75)")
+    })
+  })
+
+  describe("simpleLinearGradient", () => {
+    it("creates a gradient function with correct start color", () => {
+      const gradient = simpleLinearGradient(
+        { h: 0, s: 100, l: 50 },
+        { h: 240, s: 100, l: 50 },
+        10
+      )
+      const startColor = gradient(0)
+      expect(startColor.h).toBe(0)
+      expect(startColor.s).toBe(100)
+      expect(startColor.l).toBe(50)
+      expect(startColor.a).toBe(1)
+    })
+
+    it("creates a gradient function with correct end color", () => {
+      const gradient = simpleLinearGradient(
+        { h: 0, s: 100, l: 50 },
+        { h: 240, s: 100, l: 50 },
+        10
+      )
+      const endColor = gradient(10)
+      expect(endColor.h).toBe(240)
+      expect(endColor.s).toBe(100)
+      expect(endColor.l).toBe(50)
+    })
+
+    it("interpolates middle color correctly", () => {
+      const gradient = simpleLinearGradient(
+        { h: 0, s: 100, l: 50 },
+        { h: 240, s: 100, l: 50 },
+        10
+      )
+      const midColor = gradient(5)
+      expect(midColor.h).toBe(120)
+      expect(midColor.s).toBe(100)
+      expect(midColor.l).toBe(50)
+    })
+
+    it("handles alpha interpolation", () => {
+      const gradient = simpleLinearGradient(
+        { h: 0, s: 100, l: 50, a: 0 },
+        { h: 0, s: 100, l: 50, a: 1 },
+        10
+      )
+      expect(gradient(0).a).toBe(0)
+      expect(gradient(5).a).toBe(0.5)
+      expect(gradient(10).a).toBe(1)
+    })
+
+    it("handles missing alpha (defaults to 1)", () => {
+      const gradient = simpleLinearGradient(
+        { h: 0, s: 100, l: 50 },
+        { h: 0, s: 100, l: 50 },
+        10
+      )
+      expect(gradient(0).a).toBe(1)
+      expect(gradient(10).a).toBe(1)
+    })
+
+    it("interpolates all channels", () => {
+      const gradient = simpleLinearGradient(
+        { h: 0, s: 0, l: 0, a: 0 },
+        { h: 360, s: 100, l: 100, a: 1 },
+        10
+      )
+      const midColor = gradient(5)
+      expect(midColor.h).toBe(180)
+      expect(midColor.s).toBe(50)
+      expect(midColor.l).toBe(50)
+      expect(midColor.a).toBe(0.5)
+    })
+  })
+
+  describe("hueRange", () => {
+    it("creates a hue gradient with constant saturation and lightness", () => {
+      const hueGradient = hueRange({ h1: 0, h2: 360, s: 70, l: 50, steps: 12 })
+
+      // Start
+      const start = hueGradient(0)
+      expect(start.h).toBe(0)
+      expect(start.s).toBe(70)
+      expect(start.l).toBe(50)
+      expect(start.a).toBe(1)
+
+      // Middle
+      const mid = hueGradient(6)
+      expect(mid.h).toBe(180)
+      expect(mid.s).toBe(70)
+      expect(mid.l).toBe(50)
+
+      // End
+      const end = hueGradient(12)
+      expect(end.h).toBe(360)
+      expect(end.s).toBe(70)
+      expect(end.l).toBe(50)
+    })
+
+    it("handles custom alpha", () => {
+      const hueGradient = hueRange({ h1: 0, h2: 360, s: 70, l: 50, a: 0.5, steps: 10 })
+      expect(hueGradient(0).a).toBe(0.5)
+      expect(hueGradient(5).a).toBe(0.5)
+    })
+  })
+
+  describe("saturationRange", () => {
+    it("creates a saturation gradient with constant hue and lightness", () => {
+      const satGradient = saturationRange({ h: 0, s1: 20, s2: 100, l: 50, steps: 10 })
+
+      // Start
+      const start = satGradient(0)
+      expect(start.h).toBe(0)
+      expect(start.s).toBe(20)
+      expect(start.l).toBe(50)
+
+      // Middle
+      const mid = satGradient(5)
+      expect(mid.h).toBe(0)
+      expect(mid.s).toBe(60)
+      expect(mid.l).toBe(50)
+
+      // End
+      const end = satGradient(10)
+      expect(end.h).toBe(0)
+      expect(end.s).toBe(100)
+      expect(end.l).toBe(50)
+    })
+
+    it("handles custom alpha", () => {
+      const satGradient = saturationRange({ h: 0, s1: 0, s2: 100, l: 50, a: 0.8, steps: 10 })
+      expect(satGradient(5).a).toBe(0.8)
+    })
+  })
+
+  describe("lightnessRange", () => {
+    it("creates a lightness gradient with constant hue and saturation", () => {
+      const lightGradient = lightnessRange({ h: 240, s: 70, l1: 20, l2: 80, steps: 10 })
+
+      // Start
+      const start = lightGradient(0)
+      expect(start.h).toBe(240)
+      expect(start.s).toBe(70)
+      expect(start.l).toBe(20)
+
+      // Middle
+      const mid = lightGradient(5)
+      expect(mid.h).toBe(240)
+      expect(mid.s).toBe(70)
+      expect(mid.l).toBe(50)
+
+      // End
+      const end = lightGradient(10)
+      expect(end.h).toBe(240)
+      expect(end.s).toBe(70)
+      expect(end.l).toBe(80)
+    })
+
+    it("handles custom alpha", () => {
+      const lightGradient = lightnessRange({ h: 0, s: 50, l1: 0, l2: 100, a: 0.3, steps: 10 })
+      expect(lightGradient(5).a).toBe(0.3)
+    })
+  })
+
+  describe("alphaRange", () => {
+    it("creates an alpha gradient with constant color", () => {
+      const alphaGradient = alphaRange({ h: 0, s: 100, l: 50, a1: 0, a2: 1, steps: 10 })
+
+      // Start
+      const start = alphaGradient(0)
+      expect(start.h).toBe(0)
+      expect(start.s).toBe(100)
+      expect(start.l).toBe(50)
+      expect(start.a).toBe(0)
+
+      // Middle
+      const mid = alphaGradient(5)
+      expect(mid.a).toBe(0.5)
+
+      // End
+      const end = alphaGradient(10)
+      expect(end.a).toBe(1)
+    })
+
+    it("handles reverse alpha gradient", () => {
+      const alphaGradient = alphaRange({ h: 0, s: 100, l: 50, a1: 1, a2: 0, steps: 10 })
+      expect(alphaGradient(0).a).toBe(1)
+      expect(alphaGradient(5).a).toBe(0.5)
+      expect(alphaGradient(10).a).toBe(0)
+    })
+  })
+})

--- a/src/lib/__tests__/gradient.test.ts
+++ b/src/lib/__tests__/gradient.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from "vitest"
+import { LinearGradient, RadialGradient } from "../gradient"
+
+// Mock CanvasRenderingContext2D
+const createMockContext = () => {
+  const colorStops: Array<[number, string]> = []
+  const mockGradient = {
+    addColorStop: vi.fn((offset: number, color: string) => {
+      colorStops.push([offset, color])
+    }),
+    colorStops,
+  }
+
+  return {
+    createLinearGradient: vi.fn(
+      (x0: number, y0: number, x1: number, y1: number) => {
+        return mockGradient
+      }
+    ),
+    createRadialGradient: vi.fn(
+      (
+        x0: number,
+        y0: number,
+        r0: number,
+        x1: number,
+        y1: number,
+        r1: number
+      ) => {
+        return mockGradient
+      }
+    ),
+    mockGradient,
+  }
+}
+
+describe("gradient", () => {
+  describe("LinearGradient", () => {
+    it("creates a linear gradient with correct parameters", () => {
+      const ctx = createMockContext()
+      const gradient = new LinearGradient({
+        from: [0, 0],
+        to: [1, 0],
+        colors: [[0, { h: 0, s: 100, l: 50, a: 1 }]],
+      })
+
+      gradient.gradient(ctx as unknown as CanvasRenderingContext2D)
+
+      expect(ctx.createLinearGradient).toHaveBeenCalledWith(0, 0, 1, 0)
+    })
+
+    it("adds color stops", () => {
+      const ctx = createMockContext()
+      const gradient = new LinearGradient({
+        from: [0, 0],
+        to: [1, 0],
+        colors: [
+          [0, { h: 0, s: 100, l: 50, a: 1 }],
+          [0.5, { h: 120, s: 100, l: 50, a: 1 }],
+          [1, { h: 240, s: 100, l: 50, a: 1 }],
+        ],
+      })
+
+      gradient.gradient(ctx as unknown as CanvasRenderingContext2D)
+
+      expect(ctx.mockGradient.addColorStop).toHaveBeenCalledTimes(3)
+      expect(ctx.mockGradient.colorStops[0][0]).toBe(0)
+      expect(ctx.mockGradient.colorStops[1][0]).toBe(0.5)
+      expect(ctx.mockGradient.colorStops[2][0]).toBe(1)
+    })
+
+    it("formats color stops as HSLA strings", () => {
+      const ctx = createMockContext()
+      const gradient = new LinearGradient({
+        from: [0, 0],
+        to: [1, 0],
+        colors: [[0, { h: 180, s: 75, l: 50, a: 0.8 }]],
+      })
+
+      gradient.gradient(ctx as unknown as CanvasRenderingContext2D)
+
+      expect(ctx.mockGradient.colorStops[0][1]).toBe("hsla(180, 75%, 50%, 0.8)")
+    })
+
+    it("handles vertical gradient", () => {
+      const ctx = createMockContext()
+      const gradient = new LinearGradient({
+        from: [0.5, 0],
+        to: [0.5, 1],
+        colors: [[0, { h: 0, s: 100, l: 50, a: 1 }]],
+      })
+
+      gradient.gradient(ctx as unknown as CanvasRenderingContext2D)
+
+      expect(ctx.createLinearGradient).toHaveBeenCalledWith(0.5, 0, 0.5, 1)
+    })
+
+    it("handles diagonal gradient", () => {
+      const ctx = createMockContext()
+      const gradient = new LinearGradient({
+        from: [0, 0],
+        to: [1, 1],
+        colors: [[0, { h: 0, s: 100, l: 50, a: 1 }]],
+      })
+
+      gradient.gradient(ctx as unknown as CanvasRenderingContext2D)
+
+      expect(ctx.createLinearGradient).toHaveBeenCalledWith(0, 0, 1, 1)
+    })
+
+    it("handles missing alpha (defaults to undefined which becomes 1)", () => {
+      const ctx = createMockContext()
+      const gradient = new LinearGradient({
+        from: [0, 0],
+        to: [1, 0],
+        colors: [[0, { h: 0, s: 100, l: 50 }]],
+      })
+
+      gradient.gradient(ctx as unknown as CanvasRenderingContext2D)
+
+      // hsla function defaults alpha to 1
+      expect(ctx.mockGradient.colorStops[0][1]).toContain("hsla(0, 100%, 50%")
+    })
+  })
+
+  describe("RadialGradient", () => {
+    it("creates a radial gradient with correct parameters", () => {
+      const ctx = createMockContext()
+      const gradient = new RadialGradient({
+        start: [0.5, 0.5],
+        end: [0.5, 0.5],
+        rStart: 0,
+        rEnd: 0.4,
+        colors: [[0, { h: 0, s: 100, l: 50, a: 1 }]],
+      })
+
+      gradient.gradient(ctx as unknown as CanvasRenderingContext2D)
+
+      expect(ctx.createRadialGradient).toHaveBeenCalledWith(
+        0.5,
+        0.5,
+        0,
+        0.5,
+        0.5,
+        0.4
+      )
+    })
+
+    it("adds color stops", () => {
+      const ctx = createMockContext()
+      const gradient = new RadialGradient({
+        start: [0.5, 0.5],
+        end: [0.5, 0.5],
+        rStart: 0,
+        rEnd: 0.5,
+        colors: [
+          [0, { h: 60, s: 100, l: 70, a: 1 }],
+          [1, { h: 0, s: 100, l: 50, a: 1 }],
+        ],
+      })
+
+      gradient.gradient(ctx as unknown as CanvasRenderingContext2D)
+
+      expect(ctx.mockGradient.addColorStop).toHaveBeenCalledTimes(2)
+    })
+
+    it("handles offset center points", () => {
+      const ctx = createMockContext()
+      const gradient = new RadialGradient({
+        start: [0.3, 0.3],
+        end: [0.5, 0.5],
+        rStart: 0.1,
+        rEnd: 0.5,
+        colors: [[0, { h: 0, s: 100, l: 50, a: 1 }]],
+      })
+
+      gradient.gradient(ctx as unknown as CanvasRenderingContext2D)
+
+      expect(ctx.createRadialGradient).toHaveBeenCalledWith(
+        0.3,
+        0.3,
+        0.1,
+        0.5,
+        0.5,
+        0.5
+      )
+    })
+
+    it("formats color stops as HSLA strings", () => {
+      const ctx = createMockContext()
+      const gradient = new RadialGradient({
+        start: [0.5, 0.5],
+        end: [0.5, 0.5],
+        rStart: 0,
+        rEnd: 0.5,
+        colors: [[0.5, { h: 270, s: 80, l: 60, a: 0.9 }]],
+      })
+
+      gradient.gradient(ctx as unknown as CanvasRenderingContext2D)
+
+      expect(ctx.mockGradient.colorStops[0][1]).toBe("hsla(270, 80%, 60%, 0.9)")
+    })
+  })
+})

--- a/src/lib/__tests__/noise.test.ts
+++ b/src/lib/__tests__/noise.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest"
+import { perlin2 } from "../noise"
+
+describe("noise", () => {
+  describe("perlin2", () => {
+    it("returns values in approximate range [-1, 1]", () => {
+      // Sample many points to verify range
+      for (let i = 0; i < 100; i++) {
+        const x = Math.random() * 100
+        const y = Math.random() * 100
+        const value = perlin2(x, y)
+        expect(value).toBeGreaterThanOrEqual(-1)
+        expect(value).toBeLessThanOrEqual(1)
+      }
+    })
+
+    it("returns consistent values for same input", () => {
+      const v1 = perlin2(1.5, 2.5)
+      const v2 = perlin2(1.5, 2.5)
+      expect(v1).toBe(v2)
+    })
+
+    it("returns different values for different inputs", () => {
+      // Use non-integer coordinates since perlin2 returns 0 at integer grid points
+      const v1 = perlin2(0.5, 0.5)
+      const v2 = perlin2(1.5, 1.5)
+      const v3 = perlin2(2.5, 2.5)
+      // Not all should be the same
+      expect(v1 === v2 && v2 === v3).toBe(false)
+    })
+
+    it("produces continuous noise (nearby points have similar values)", () => {
+      const base = perlin2(5, 5)
+      const nearby1 = perlin2(5.001, 5)
+      const nearby2 = perlin2(5, 5.001)
+
+      // Nearby points should be close in value
+      expect(Math.abs(base - nearby1)).toBeLessThan(0.1)
+      expect(Math.abs(base - nearby2)).toBeLessThan(0.1)
+    })
+
+    it("handles negative coordinates", () => {
+      const value = perlin2(-5, -5)
+      expect(value).toBeGreaterThanOrEqual(-1)
+      expect(value).toBeLessThanOrEqual(1)
+    })
+
+    it("handles zero coordinates", () => {
+      const value = perlin2(0, 0)
+      expect(typeof value).toBe("number")
+      expect(isNaN(value)).toBe(false)
+    })
+
+    it("handles large coordinates", () => {
+      const value = perlin2(1000, 1000)
+      expect(value).toBeGreaterThanOrEqual(-1)
+      expect(value).toBeLessThanOrEqual(1)
+    })
+
+    it("produces varied output across a grid", () => {
+      const values = new Set<number>()
+      for (let x = 0; x < 10; x++) {
+        for (let y = 0; y < 10; y++) {
+          // Use non-integer coordinates to avoid grid points where noise is 0
+          values.add(perlin2(x * 0.3 + 0.1, y * 0.3 + 0.1))
+        }
+      }
+      // Should have many unique values
+      expect(values.size).toBeGreaterThan(20)
+    })
+
+    it("returns 0 at integer coordinates (expected behavior)", () => {
+      // Perlin noise typically returns 0 at integer grid points
+      const value = perlin2(0, 0)
+      expect(value).toBeCloseTo(0, 1)
+    })
+
+    it("is not just returning zeros", () => {
+      let nonZeroCount = 0
+      for (let i = 0; i < 100; i++) {
+        const value = perlin2(i * 0.1 + 0.05, i * 0.1 + 0.05)
+        if (Math.abs(value) > 0.01) {
+          nonZeroCount++
+        }
+      }
+      expect(nonZeroCount).toBeGreaterThan(50)
+    })
+  })
+})

--- a/src/lib/__tests__/palette.test.ts
+++ b/src/lib/__tests__/palette.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest"
+import { palette, palettePreset } from "../palette"
+
+describe("palette", () => {
+  describe("palette function", () => {
+    it("generates correct number of colors", () => {
+      const colors = palette({
+        a: [0.5, 0.5, 0.5],
+        b: [0.5, 0.5, 0.5],
+        c: [1.0, 1.0, 1.0],
+        d: [0.0, 0.33, 0.67],
+        steps: 10,
+      })
+      expect(colors).toHaveLength(10)
+    })
+
+    it("returns HSL color tuples", () => {
+      const colors = palette({
+        a: [0.5, 0.5, 0.5],
+        b: [0.5, 0.5, 0.5],
+        c: [1.0, 1.0, 1.0],
+        d: [0.0, 0.33, 0.67],
+        steps: 5,
+      })
+
+      colors.forEach((color) => {
+        expect(color).toHaveLength(3)
+        const [h, s, l] = color
+        // Hue should be 0-360
+        expect(h).toBeGreaterThanOrEqual(0)
+        expect(h).toBeLessThanOrEqual(360)
+        // Saturation should be 0-100
+        expect(s).toBeGreaterThanOrEqual(0)
+        expect(s).toBeLessThanOrEqual(100)
+        // Lightness should be 0-100
+        expect(l).toBeGreaterThanOrEqual(0)
+        expect(l).toBeLessThanOrEqual(100)
+      })
+    })
+
+    it("generates different colors for different positions", () => {
+      const colors = palette({
+        a: [0.5, 0.5, 0.5],
+        b: [0.5, 0.5, 0.5],
+        c: [1.0, 1.0, 1.0],
+        d: [0.0, 0.33, 0.67],
+        steps: 10,
+      })
+
+      // Check that not all colors are the same
+      const uniqueHues = new Set(colors.map((c) => Math.round(c[0])))
+      expect(uniqueHues.size).toBeGreaterThan(1)
+    })
+
+    it("handles single step", () => {
+      const colors = palette({
+        a: [0.5, 0.5, 0.5],
+        b: [0.5, 0.5, 0.5],
+        c: [1.0, 1.0, 1.0],
+        d: [0.0, 0.33, 0.67],
+        steps: 1,
+      })
+      expect(colors).toHaveLength(1)
+    })
+  })
+
+  describe("palettePreset function", () => {
+    it("generates rainbow palette", () => {
+      const colors = palettePreset("rainbow", 12)
+      expect(colors).toHaveLength(12)
+
+      // Rainbow should have varied hues
+      const hues = colors.map((c) => c[0])
+      const minHue = Math.min(...hues)
+      const maxHue = Math.max(...hues)
+      expect(maxHue - minHue).toBeGreaterThan(100) // Should span at least 100 degrees
+    })
+
+    it("generates warmth palette", () => {
+      const colors = palettePreset("warmth", 8)
+      expect(colors).toHaveLength(8)
+
+      // Warmth should have colors in the warm range
+      colors.forEach((color) => {
+        expect(color).toHaveLength(3)
+      })
+    })
+
+    it("generates rusty palette", () => {
+      const colors = palettePreset("rusty", 6)
+      expect(colors).toHaveLength(6)
+    })
+
+    it("generates autumnal palette", () => {
+      const colors = palettePreset("autumnal", 8)
+      expect(colors).toHaveLength(8)
+    })
+
+    it("generates natural palette", () => {
+      const colors = palettePreset("natural", 10)
+      expect(colors).toHaveLength(10)
+    })
+
+    it("generates neon palette", () => {
+      const colors = palettePreset("neon", 5)
+      expect(colors).toHaveLength(5)
+    })
+
+    it("generates subtle palette", () => {
+      const colors = palettePreset("subtle", 7)
+      expect(colors).toHaveLength(7)
+    })
+
+    it("all presets produce valid HSL colors", () => {
+      const presets = [
+        "rainbow",
+        "warmth",
+        "rusty",
+        "autumnal",
+        "natural",
+        "neon",
+        "subtle",
+      ] as const
+
+      presets.forEach((preset) => {
+        const colors = palettePreset(preset, 5)
+        colors.forEach((color) => {
+          const [h, s, l] = color
+          expect(h).toBeGreaterThanOrEqual(0)
+          expect(s).toBeGreaterThanOrEqual(0)
+          expect(l).toBeGreaterThanOrEqual(0)
+        })
+      })
+    })
+  })
+})

--- a/src/lib/__tests__/paths.test.ts
+++ b/src/lib/__tests__/paths.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it } from "vitest"
+import { Circle } from "../paths/Circle"
+import { Ellipse } from "../paths/Ellipse"
+import { Rect } from "../paths/Rect"
+import { SimplePath } from "../paths/SimplePath"
+import { Point2D } from "../types/sol"
+
+describe("paths", () => {
+  describe("Rect", () => {
+    it("creates a rectangle with topLeft alignment (default)", () => {
+      const rect = new Rect({ at: [0, 0], w: 10, h: 5 })
+      expect(rect.at).toEqual([0, 0])
+      expect(rect.w).toBe(10)
+      expect(rect.h).toBe(5)
+    })
+
+    it("creates a rectangle with center alignment", () => {
+      const rect = new Rect({ at: [5, 5], w: 10, h: 10, align: "center" })
+      expect(rect.at).toEqual([0, 0])
+      expect(rect.w).toBe(10)
+      expect(rect.h).toBe(10)
+    })
+
+    it("converts to SimplePath with correct points", () => {
+      const rect = new Rect({ at: [0, 0], w: 2, h: 3 })
+      const path = rect.path
+      expect(path.points).toHaveLength(5) // 4 corners + closing point
+      expect(path.points[0]).toEqual([0, 0])
+      expect(path.points[1]).toEqual([2, 0])
+      expect(path.points[2]).toEqual([2, 3])
+      expect(path.points[3]).toEqual([0, 3])
+      expect(path.points[4]).toEqual([0, 0]) // closed
+    })
+
+    describe("split", () => {
+      it("splits horizontally in half", () => {
+        const rect = new Rect({ at: [0, 0], w: 10, h: 10 })
+        const [left, right] = rect.split({ orientation: "horizontal" })
+
+        expect(left.at).toEqual([0, 0])
+        expect(left.w).toBe(5)
+        expect(left.h).toBe(10)
+
+        expect(right.at).toEqual([5, 0])
+        expect(right.w).toBe(5)
+        expect(right.h).toBe(10)
+      })
+
+      it("splits vertically in half", () => {
+        const rect = new Rect({ at: [0, 0], w: 10, h: 10 })
+        const [top, bottom] = rect.split({ orientation: "vertical" })
+
+        expect(top.at).toEqual([0, 0])
+        expect(top.w).toBe(10)
+        expect(top.h).toBe(5)
+
+        expect(bottom.at).toEqual([0, 5])
+        expect(bottom.w).toBe(10)
+        expect(bottom.h).toBe(5)
+      })
+
+      it("splits horizontally with proportions", () => {
+        const rect = new Rect({ at: [0, 0], w: 10, h: 10 })
+        const parts = rect.split({ orientation: "horizontal", split: [1, 2, 1] })
+
+        expect(parts).toHaveLength(3)
+        expect(parts[0].w).toBe(2.5)
+        expect(parts[1].w).toBe(5)
+        expect(parts[2].w).toBe(2.5)
+      })
+
+      it("splits vertically with proportions", () => {
+        const rect = new Rect({ at: [0, 0], w: 10, h: 10 })
+        const parts = rect.split({ orientation: "vertical", split: [1, 1] })
+
+        expect(parts).toHaveLength(2)
+        expect(parts[0].h).toBe(5)
+        expect(parts[1].h).toBe(5)
+      })
+    })
+  })
+
+  describe("Ellipse", () => {
+    it("creates an ellipse with center alignment (default)", () => {
+      const ellipse = new Ellipse({ at: [0.5, 0.5], w: 0.4, h: 0.3 })
+      // Ellipse stores config internally
+      expect(ellipse).toBeDefined()
+    })
+
+    it("converts to SimplePath with detail 0 (diamond)", () => {
+      const ellipse = new Ellipse({ at: [0.5, 0.5], w: 0.4, h: 0.3 })
+      const path = ellipse.toPath(0)
+      expect(path.points).toHaveLength(5) // 4 points + closing
+    })
+
+    it("converts to SimplePath with higher detail", () => {
+      const ellipse = new Ellipse({ at: [0.5, 0.5], w: 0.4, h: 0.3 })
+      const path = ellipse.toPath(12)
+      expect(path.points.length).toBeGreaterThan(5)
+    })
+
+    it("handles topLeft alignment", () => {
+      const ellipse = new Ellipse({ at: [0, 0], w: 1, h: 1, align: "topLeft" })
+      const path = ellipse.toPath(0)
+      // Should be centered at (0.5, 0.5) when aligned topLeft
+      const points = path.points
+      expect(points).toContainEqual([0.5, 0])
+      expect(points).toContainEqual([1, 0.5])
+      expect(points).toContainEqual([0.5, 1])
+      expect(points).toContainEqual([0, 0.5])
+    })
+  })
+
+  describe("Circle", () => {
+    it("creates a circle (extends Ellipse)", () => {
+      const circle = new Circle({ at: [0.5, 0.5], r: 0.2 })
+      expect(circle).toBeInstanceOf(Ellipse)
+    })
+
+    it("converts to path correctly", () => {
+      const circle = new Circle({ at: [0.5, 0.5], r: 0.2 })
+      const path = circle.toPath(0)
+      expect(path.points).toHaveLength(5)
+
+      // Check cardinal points
+      const points = path.points
+      const topExists = points.some(p => Math.abs(p[0] - 0.5) < 0.01 && Math.abs(p[1] - 0.3) < 0.01)
+      const rightExists = points.some(p => Math.abs(p[0] - 0.7) < 0.01 && Math.abs(p[1] - 0.5) < 0.01)
+      expect(topExists).toBe(true)
+      expect(rightExists).toBe(true)
+    })
+  })
+
+  describe("SimplePath", () => {
+    describe("creation", () => {
+      it("creates empty path", () => {
+        const path = new SimplePath()
+        expect(path.points).toEqual([])
+      })
+
+      it("creates path with initial points", () => {
+        const path = new SimplePath([[0, 0], [1, 1]])
+        expect(path.points).toEqual([[0, 0], [1, 1]])
+      })
+
+      it("creates path using startAt", () => {
+        const path = SimplePath.startAt([0, 0])
+        expect(path.points).toEqual([[0, 0]])
+      })
+
+      it("creates path using withPoints", () => {
+        const path = SimplePath.withPoints([[0, 0], [1, 0], [1, 1]])
+        expect(path.points).toEqual([[0, 0], [1, 0], [1, 1]])
+      })
+    })
+
+    describe("addPoint", () => {
+      it("adds a point to the path", () => {
+        const path = SimplePath.startAt([0, 0])
+        path.addPoint([1, 1])
+        expect(path.points).toEqual([[0, 0], [1, 1]])
+      })
+
+      it("chains addPoint calls", () => {
+        const path = SimplePath.startAt([0, 0])
+          .addPoint([1, 0])
+          .addPoint([1, 1])
+          .addPoint([0, 1])
+        expect(path.points).toHaveLength(4)
+      })
+    })
+
+    describe("close", () => {
+      it("closes the path by repeating first point", () => {
+        const path = SimplePath.withPoints([[0, 0], [1, 0], [1, 1]]).close()
+        expect(path.points).toHaveLength(4)
+        expect(path.points[3]).toEqual([0, 0])
+      })
+
+      it("handles empty path", () => {
+        const path = new SimplePath().close()
+        expect(path.points).toEqual([])
+      })
+    })
+
+    describe("centroid", () => {
+      it("calculates centroid of triangle", () => {
+        const path = SimplePath.withPoints([[0, 0], [3, 0], [0, 3]])
+        const c = path.centroid
+        expect(c[0]).toBe(1)
+        expect(c[1]).toBe(1)
+      })
+
+      it("calculates centroid of square", () => {
+        const path = SimplePath.withPoints([[0, 0], [2, 0], [2, 2], [0, 2]])
+        const c = path.centroid
+        expect(c[0]).toBe(1)
+        expect(c[1]).toBe(1)
+      })
+    })
+
+    describe("moved", () => {
+      it("moves path by delta", () => {
+        const path = SimplePath.withPoints([[0, 0], [1, 1]])
+        const moved = path.moved([5, 5])
+        expect(moved.points).toEqual([[5, 5], [6, 6]])
+      })
+
+      it("returns new path (doesn't mutate)", () => {
+        const path = SimplePath.withPoints([[0, 0], [1, 1]])
+        const moved = path.moved([5, 5])
+        expect(path.points).toEqual([[0, 0], [1, 1]])
+        expect(moved.points).toEqual([[5, 5], [6, 6]])
+      })
+    })
+
+    describe("scaled", () => {
+      it("scales path around centroid", () => {
+        const path = SimplePath.withPoints([[0, 0], [2, 0], [2, 2], [0, 2]])
+        const scaled = path.scaled(2)
+        // Centroid is (1, 1), so points should move away by factor of 2
+        expect(scaled.centroid[0]).toBeCloseTo(1)
+        expect(scaled.centroid[1]).toBeCloseTo(1)
+        // Check a corner point
+        expect(scaled.points[0][0]).toBeCloseTo(-1)
+        expect(scaled.points[0][1]).toBeCloseTo(-1)
+      })
+    })
+
+    describe("reversed", () => {
+      it("reverses point order", () => {
+        const path = SimplePath.withPoints([[0, 0], [1, 0], [1, 1]])
+        const reversed = path.reversed
+        expect(reversed.points).toEqual([[1, 1], [1, 0], [0, 0]])
+      })
+    })
+
+    describe("transformed", () => {
+      it("applies transformation to all points", () => {
+        const path = SimplePath.withPoints([[0, 0], [1, 1]])
+        const doubled = path.transformed(([x, y]) => [x * 2, y * 2])
+        expect(doubled.points).toEqual([[0, 0], [2, 2]])
+      })
+    })
+
+    describe("rotated", () => {
+      it("rotates path around centroid", () => {
+        const path = SimplePath.withPoints([[0, 0], [2, 0], [2, 2], [0, 2]])
+        const rotated = path.rotated(Math.PI)
+        // After 180 degree rotation, centroid should be the same
+        expect(rotated.centroid[0]).toBeCloseTo(1)
+        expect(rotated.centroid[1]).toBeCloseTo(1)
+        // Points should be reflected
+        expect(rotated.points[0][0]).toBeCloseTo(2)
+        expect(rotated.points[0][1]).toBeCloseTo(2)
+      })
+    })
+
+    describe("withAppended", () => {
+      it("appends another path", () => {
+        const path1 = SimplePath.withPoints([[0, 0], [1, 0]])
+        const path2 = SimplePath.withPoints([[1, 1], [0, 1]])
+        const combined = path1.withAppended(path2)
+        expect(combined.points).toEqual([[0, 0], [1, 0], [1, 1], [0, 1]])
+      })
+    })
+
+    describe("edges", () => {
+      it("returns array of edge paths", () => {
+        const path = SimplePath.withPoints([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]])
+        const edges = path.edges
+        expect(edges).toHaveLength(4)
+        expect(edges[0].points).toEqual([[0, 0], [1, 0]])
+        expect(edges[1].points).toEqual([[1, 0], [1, 1]])
+        expect(edges[2].points).toEqual([[1, 1], [0, 1]])
+        expect(edges[3].points).toEqual([[0, 1], [0, 0]])
+      })
+    })
+
+    describe("segmented", () => {
+      it("splits path into triangular segments around centroid", () => {
+        const path = SimplePath.withPoints([[0, 0], [2, 0], [2, 2], [0, 2], [0, 0]])
+        const segments = path.segmented
+        expect(segments).toHaveLength(4)
+        // Each segment should have centroid as one of its points
+        segments.forEach(seg => {
+          const hasCenter = seg.points.some(
+            p => Math.abs(p[0] - 1) < 0.01 && Math.abs(p[1] - 1) < 0.01
+          )
+          expect(hasCenter).toBe(true)
+        })
+      })
+
+      it("throws error with less than 2 points", () => {
+        const path = SimplePath.withPoints([[0, 0]])
+        expect(() => path.segmented).toThrow("Must have at least 2 points")
+      })
+    })
+
+    describe("exploded", () => {
+      it("creates exploded triangular segments", () => {
+        const path = SimplePath.withPoints([[0, 0], [2, 0], [2, 2], [0, 2], [0, 0]])
+        const exploded = path.exploded({ magnitude: 1.5, scale: 1 })
+        expect(exploded).toHaveLength(4)
+      })
+
+      it("uses default values", () => {
+        const path = SimplePath.withPoints([[0, 0], [2, 0], [2, 2], [0, 2], [0, 0]])
+        const exploded = path.exploded()
+        expect(exploded).toHaveLength(4)
+      })
+    })
+
+    describe("chaiken", () => {
+      it("smooths path with chaiken algorithm", () => {
+        const path = SimplePath.withPoints([[0, 0], [1, 0], [1, 1], [0, 1]])
+        const smoothed = path.chaiken({ n: 1 })
+        // Chaiken adds more points
+        expect(smoothed.points.length).toBeGreaterThan(4)
+      })
+
+      it("handles multiple iterations", () => {
+        const path = SimplePath.withPoints([[0, 0], [1, 0], [1, 1], [0, 1]])
+        const smoothed = path.chaiken({ n: 2 })
+        expect(smoothed.points.length).toBeGreaterThan(8)
+      })
+    })
+
+    describe("transformPoints", () => {
+      it("mutates points in place", () => {
+        const path = SimplePath.withPoints([[0, 0], [1, 1]])
+        path.transformPoints(([x, y]) => [x + 1, y + 1])
+        expect(path.points).toEqual([[1, 1], [2, 2]])
+      })
+    })
+  })
+})

--- a/src/lib/__tests__/sCanvas.test.ts
+++ b/src/lib/__tests__/sCanvas.test.ts
@@ -1,0 +1,500 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import SCanvas from "../sCanvas"
+import { Rect } from "../paths/Rect"
+import { Circle } from "../paths/Circle"
+
+// Create a mock canvas context
+const createMockCtx = () => {
+  const history: string[] = []
+  const ctx = new Proxy(
+    {
+      fillStyle: '',
+      strokeStyle: '',
+      lineWidth: 0,
+      lineCap: 'butt',
+      lineJoin: 'miter',
+      shadowBlur: 0,
+      shadowColor: '',
+      shadowOffsetX: 0,
+      shadowOffsetY: 0,
+      globalCompositeOperation: 'source-over',
+    } as any,
+    {
+      get: function(target, property) {
+        if (property in target) {
+          return target[property]
+        }
+        history.push(`${String(property)}`)
+        return (...args: any[]) => {
+          history[history.length - 1] = `${String(property)}(${args.join(', ')})`
+        }
+      },
+      set: function(target, property, value) {
+        history.push(`${String(property)} = ${value}`)
+        target[property] = value
+        return true
+      },
+    }
+  )
+  return { ctx: ctx as CanvasRenderingContext2D, history }
+}
+
+describe("SCanvas", () => {
+  describe("constructor", () => {
+    it("initializes with correct aspect ratio", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 1000, height: 500 }, 42)
+      expect(s.aspectRatio).toBe(2) // 1000/500
+    })
+
+    it("initializes meta with correct values", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 1000, height: 1000 }, 42)
+      expect(s.meta.top).toBe(0)
+      expect(s.meta.left).toBe(0)
+      expect(s.meta.right).toBe(1)
+      expect(s.meta.bottom).toBe(1) // height/width = aspectRatio
+      expect(s.meta.center).toEqual([0.5, 0.5])
+    })
+
+    it("initializes with default time 0", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      expect(s.t).toBe(0)
+    })
+
+    it("initializes with custom time", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42, 0.5)
+      expect(s.t).toBe(0.5)
+    })
+  })
+
+  describe("updateTime", () => {
+    it("updates the time value", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      s.updateTime(0.75)
+      expect(s.t).toBe(0.75)
+    })
+  })
+
+  describe("updateSize", () => {
+    it("updates aspect ratio and meta", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      s.updateSize({ width: 200, height: 100 })
+      expect(s.aspectRatio).toBe(2)
+      expect(s.meta.bottom).toBe(0.5)
+    })
+  })
+
+  describe("resetRandomNumberGenerator", () => {
+    it("resets RNG with new seed", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      const val1 = s.random()
+      s.resetRandomNumberGenerator(42)
+      const val2 = s.random()
+      expect(val1).toBe(val2) // Same seed = same sequence
+    })
+  })
+
+  describe("random", () => {
+    it("returns values between 0 and 1", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      for (let i = 0; i < 100; i++) {
+        const val = s.random()
+        expect(val).toBeGreaterThanOrEqual(0)
+        expect(val).toBeLessThan(1)
+      }
+    })
+
+    it("is reproducible with same seed", () => {
+      const { ctx: ctx1 } = createMockCtx()
+      const { ctx: ctx2 } = createMockCtx()
+      const s1 = new SCanvas(ctx1, { width: 100, height: 100 }, 123)
+      const s2 = new SCanvas(ctx2, { width: 100, height: 100 }, 123)
+
+      for (let i = 0; i < 10; i++) {
+        expect(s1.random()).toBe(s2.random())
+      }
+    })
+  })
+
+  describe("uniformRandomInt", () => {
+    it("returns integers in specified range (inclusive)", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      const values = new Set<number>()
+      for (let i = 0; i < 1000; i++) {
+        const val = s.uniformRandomInt({ from: 1, to: 5 })
+        expect(Number.isInteger(val)).toBe(true)
+        expect(val).toBeGreaterThanOrEqual(1)
+        expect(val).toBeLessThanOrEqual(5)
+        values.add(val)
+      }
+      // Should hit all values 1-5
+      expect(values.size).toBe(5)
+    })
+
+    it("returns integers in specified range (exclusive)", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      for (let i = 0; i < 100; i++) {
+        const val = s.uniformRandomInt({ from: 0, to: 5, inclusive: false })
+        expect(val).toBeGreaterThanOrEqual(0)
+        expect(val).toBeLessThan(5)
+      }
+    })
+  })
+
+  describe("gaussian", () => {
+    it("generates values with approximate mean and sd", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      const values: number[] = []
+      for (let i = 0; i < 1000; i++) {
+        values.push(s.gaussian({ mean: 10, sd: 2 }))
+      }
+      const mean = values.reduce((a, b) => a + b, 0) / values.length
+      expect(mean).toBeCloseTo(10, 0) // Mean should be close to 10
+    })
+  })
+
+  describe("poisson", () => {
+    it("generates non-negative integers", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      for (let i = 0; i < 100; i++) {
+        const val = s.poisson(5)
+        expect(Number.isInteger(val)).toBe(true)
+        expect(val).toBeGreaterThanOrEqual(0)
+      }
+    })
+  })
+
+  describe("sample", () => {
+    it("returns an element from the array", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      const arr = [1, 2, 3, 4, 5]
+      for (let i = 0; i < 10; i++) {
+        expect(arr).toContain(s.sample(arr))
+      }
+    })
+  })
+
+  describe("samples", () => {
+    it("returns n samples from the array", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      const arr = ['a', 'b', 'c']
+      const result = s.samples(5, arr)
+      expect(result).toHaveLength(5)
+      result.forEach(item => expect(arr).toContain(item))
+    })
+  })
+
+  describe("shuffle", () => {
+    it("shuffles array in place", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      const original = [...arr]
+      s.shuffle(arr)
+      // Should have same elements
+      expect([...arr].sort()).toEqual([...original].sort())
+      // Unlikely to be in same order (technically possible but extremely rare)
+      expect(arr.join('')).not.toBe(original.join(''))
+    })
+  })
+
+  describe("perturb", () => {
+    it("perturbs a point within magnitude", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      const original: [number, number] = [0.5, 0.5]
+      for (let i = 0; i < 100; i++) {
+        const [x, y] = s.perturb({ at: original, magnitude: 0.1 })
+        expect(Math.abs(x - 0.5)).toBeLessThanOrEqual(0.05)
+        expect(Math.abs(y - 0.5)).toBeLessThanOrEqual(0.05)
+      }
+    })
+  })
+
+  describe("randomPoint", () => {
+    it("returns a point within canvas bounds", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      for (let i = 0; i < 100; i++) {
+        const [x, y] = s.randomPoint()
+        expect(x).toBeGreaterThanOrEqual(0)
+        expect(x).toBeLessThan(1)
+        expect(y).toBeGreaterThanOrEqual(0)
+        expect(y).toBeLessThan(1) // aspectRatio is 1
+      }
+    })
+  })
+
+  describe("randomAngle", () => {
+    it("returns angle between 0 and 2*PI", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      for (let i = 0; i < 100; i++) {
+        const angle = s.randomAngle()
+        expect(angle).toBeGreaterThanOrEqual(0)
+        expect(angle).toBeLessThan(Math.PI * 2)
+      }
+    })
+  })
+
+  describe("randomPolarity", () => {
+    it("returns -1 or 1", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      const results = new Set<number>()
+      for (let i = 0; i < 100; i++) {
+        const val = s.randomPolarity()
+        expect(val === -1 || val === 1).toBe(true)
+        results.add(val)
+      }
+      expect(results.has(-1)).toBe(true)
+      expect(results.has(1)).toBe(true)
+    })
+  })
+
+  describe("times", () => {
+    it("calls callback n times", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      const indices: number[] = []
+      s.times(5, (i) => indices.push(i))
+      expect(indices).toEqual([0, 1, 2, 3, 4])
+    })
+  })
+
+  describe("downFrom", () => {
+    it("counts down from n to 1", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      const indices: number[] = []
+      s.downFrom(5, (i) => indices.push(i))
+      expect(indices).toEqual([5, 4, 3, 2, 1])
+    })
+  })
+
+  describe("forTiling", () => {
+    it("iterates over a grid", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      const positions: [number, number][] = []
+      s.forTiling({ n: 2 }, ([x, y]) => {
+        positions.push([x, y])
+      })
+      // 2x2 grid = 4 tiles
+      expect(positions).toHaveLength(4)
+    })
+
+    it("passes correct size to callback", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      const sizes: [number, number][] = []
+      s.forTiling({ n: 4 }, (_, [w, h]) => {
+        sizes.push([w, h])
+      })
+      // Each tile should be 0.25 x 0.25
+      sizes.forEach(([w, h]) => {
+        expect(w).toBeCloseTo(0.25)
+        expect(h).toBeCloseTo(0.25)
+      })
+    })
+
+    it("passes correct center to callback", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      let firstCenter: [number, number] | null = null
+      s.forTiling({ n: 2 }, (_, __, [cx, cy], i) => {
+        if (i === 0) firstCenter = [cx, cy]
+      })
+      // First tile center should be at (0.25, 0.25)
+      expect(firstCenter![0]).toBeCloseTo(0.25)
+      expect(firstCenter![1]).toBeCloseTo(0.25)
+    })
+
+    it("respects margin parameter", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      let firstPos: [number, number] | null = null
+      s.forTiling({ n: 2, margin: 0.1 }, ([x, y]) => {
+        if (!firstPos) firstPos = [x, y]
+      })
+      expect(firstPos![0]).toBeCloseTo(0.1)
+    })
+  })
+
+  describe("forHorizontal", () => {
+    it("iterates horizontally", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      const positions: number[] = []
+      s.forHorizontal({ n: 4 }, ([x]) => positions.push(x))
+      expect(positions).toHaveLength(4)
+      // Each should start at 0, 0.25, 0.5, 0.75
+      expect(positions[0]).toBeCloseTo(0)
+      expect(positions[1]).toBeCloseTo(0.25)
+    })
+  })
+
+  describe("forVertical", () => {
+    it("iterates vertically", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      const positions: number[] = []
+      s.forVertical({ n: 4 }, ([_, y]) => positions.push(y))
+      expect(positions).toHaveLength(4)
+    })
+  })
+
+  describe("forGrid", () => {
+    it("iterates over integer grid", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      const points: [number, number][] = []
+      s.forGrid({ minX: 0, maxX: 2, minY: 0, maxY: 2 }, ([x, y]) => {
+        points.push([x, y])
+      })
+      // 3x3 grid = 9 points
+      expect(points).toHaveLength(9)
+      expect(points).toContainEqual([0, 0])
+      expect(points).toContainEqual([2, 2])
+    })
+  })
+
+  describe("aroundCircle", () => {
+    it("iterates around a circle", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      const points: [number, number][] = []
+      s.aroundCircle({ n: 4, at: [0.5, 0.5], r: 0.2 }, ([x, y]) => {
+        points.push([x, y])
+      })
+      expect(points).toHaveLength(4)
+      // All points should be at distance r from center
+      points.forEach(([x, y]) => {
+        const dist = Math.sqrt((x - 0.5) ** 2 + (y - 0.5) ** 2)
+        expect(dist).toBeCloseTo(0.2, 1)
+      })
+    })
+  })
+
+  describe("range", () => {
+    it("iterates over a range", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      const values: number[] = []
+      s.range({ from: 0, to: 1, n: 4 }, (val) => values.push(val))
+      expect(values).toHaveLength(5) // inclusive by default
+      expect(values[0]).toBe(0)
+      expect(values[4]).toBe(1)
+    })
+
+    it("respects inclusive=false", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      const values: number[] = []
+      s.range({ from: 0, to: 1, n: 4, inclusive: false }, (val) => values.push(val))
+      expect(values).toHaveLength(4)
+    })
+  })
+
+  describe("build", () => {
+    it("collects values from iteration", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      const centers = s.build(s.forTiling, { n: 2 }, (_, __, center) => center)
+      expect(centers).toHaveLength(4)
+    })
+  })
+
+  describe("proportionately", () => {
+    it("selects based on weights", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+
+      const counts = { a: 0, b: 0 }
+      for (let i = 0; i < 1000; i++) {
+        s.resetRandomNumberGenerator(i)
+        const result = s.proportionately([
+          [7, () => 'a'],
+          [3, () => 'b'],
+        ])
+        counts[result as 'a' | 'b']++
+      }
+
+      // 'a' should be selected about 70% of the time
+      expect(counts.a).toBeGreaterThan(600)
+      expect(counts.b).toBeGreaterThan(200)
+    })
+
+    it("throws with zero total", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      expect(() => s.proportionately([[0, () => 'a']])).toThrow("Must be positive total")
+    })
+  })
+
+  describe("doProportion", () => {
+    it("executes callback based on probability", () => {
+      const { ctx } = createMockCtx()
+      let count = 0
+
+      for (let i = 0; i < 1000; i++) {
+        const s = new SCanvas(ctx, { width: 100, height: 100 }, i)
+        s.doProportion(0.3, () => count++)
+      }
+
+      // Should execute roughly 30% of the time
+      expect(count).toBeGreaterThan(200)
+      expect(count).toBeLessThan(400)
+    })
+  })
+
+  describe("inDrawing", () => {
+    it("returns true for points inside canvas", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      expect(s.inDrawing([0.5, 0.5])).toBe(true)
+    })
+
+    it("returns false for points outside canvas", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42)
+      expect(s.inDrawing([-0.1, 0.5])).toBe(false)
+      expect(s.inDrawing([1.1, 0.5])).toBe(false)
+      expect(s.inDrawing([0.5, -0.1])).toBe(false)
+      expect(s.inDrawing([0.5, 1.1])).toBe(false)
+    })
+  })
+
+  describe("oscillate", () => {
+    it("oscillates between from and to", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42, 0)
+
+      // At t=0, cos(0) = 1, so value = from + (to-from)*(1+1)/2 = from + (to-from) = to
+      const atZero = s.oscillate({ from: 0, to: 10 })
+      expect(atZero).toBeCloseTo(10)
+    })
+
+    it("uses default values", () => {
+      const { ctx } = createMockCtx()
+      const s = new SCanvas(ctx, { width: 100, height: 100 }, 42, Math.PI)
+
+      // At t=PI, cos(PI) = -1, so value = 0 + (1-0)*(1-1)/2 = 0
+      const val = s.oscillate()
+      expect(val).toBeCloseTo(0)
+    })
+  })
+})

--- a/src/lib/__tests__/vectors.test.ts
+++ b/src/lib/__tests__/vectors.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from "vitest"
+import {
+  add,
+  subtract,
+  magnitude,
+  distance,
+  rotate,
+  rotateAround,
+  normalize,
+  scale,
+  polarToCartesian,
+  pointAlong,
+  dot,
+} from "../vectors"
+
+describe("vectors", () => {
+  describe("add", () => {
+    it("adds two vectors", () => {
+      expect(add([1, 2], [3, 4])).toEqual([4, 6])
+    })
+
+    it("handles negative values", () => {
+      expect(add([1, -2], [-3, 4])).toEqual([-2, 2])
+    })
+
+    it("handles zero vectors", () => {
+      expect(add([0, 0], [5, 5])).toEqual([5, 5])
+      expect(add([5, 5], [0, 0])).toEqual([5, 5])
+    })
+
+    it("handles decimals", () => {
+      expect(add([0.5, 0.25], [0.25, 0.5])).toEqual([0.75, 0.75])
+    })
+  })
+
+  describe("subtract", () => {
+    it("subtracts two vectors", () => {
+      expect(subtract([5, 7], [2, 3])).toEqual([3, 4])
+    })
+
+    it("handles negative results", () => {
+      expect(subtract([1, 2], [3, 4])).toEqual([-2, -2])
+    })
+
+    it("handles zero vectors", () => {
+      expect(subtract([5, 5], [0, 0])).toEqual([5, 5])
+      expect(subtract([5, 5], [5, 5])).toEqual([0, 0])
+    })
+  })
+
+  describe("magnitude", () => {
+    it("calculates magnitude of a 3-4-5 triangle", () => {
+      expect(magnitude([3, 4])).toBe(5)
+    })
+
+    it("handles zero vector", () => {
+      expect(magnitude([0, 0])).toBe(0)
+    })
+
+    it("handles unit vectors", () => {
+      expect(magnitude([1, 0])).toBe(1)
+      expect(magnitude([0, 1])).toBe(1)
+    })
+
+    it("handles negative values", () => {
+      expect(magnitude([-3, -4])).toBe(5)
+    })
+
+    it("handles diagonal unit", () => {
+      expect(magnitude([1, 1])).toBeCloseTo(Math.SQRT2)
+    })
+  })
+
+  describe("distance", () => {
+    it("calculates distance between two points", () => {
+      expect(distance([0, 0], [3, 4])).toBe(5)
+    })
+
+    it("returns 0 for same points", () => {
+      expect(distance([5, 5], [5, 5])).toBe(0)
+    })
+
+    it("is commutative", () => {
+      expect(distance([0, 0], [3, 4])).toBe(distance([3, 4], [0, 0]))
+    })
+
+    it("handles negative coordinates", () => {
+      expect(distance([-1, -1], [2, 3])).toBe(5)
+    })
+  })
+
+  describe("rotate", () => {
+    it("rotates by 90 degrees", () => {
+      const result = rotate([1, 0], Math.PI / 2)
+      expect(result[0]).toBeCloseTo(0)
+      expect(result[1]).toBeCloseTo(1)
+    })
+
+    it("rotates by 180 degrees", () => {
+      const result = rotate([1, 0], Math.PI)
+      expect(result[0]).toBeCloseTo(-1)
+      expect(result[1]).toBeCloseTo(0)
+    })
+
+    it("rotates by 0 degrees (no change)", () => {
+      const result = rotate([1, 0], 0)
+      expect(result[0]).toBeCloseTo(1)
+      expect(result[1]).toBeCloseTo(0)
+    })
+
+    it("rotates by -90 degrees", () => {
+      const result = rotate([1, 0], -Math.PI / 2)
+      expect(result[0]).toBeCloseTo(0)
+      expect(result[1]).toBeCloseTo(-1)
+    })
+
+    it("rotates by 360 degrees (full circle)", () => {
+      const result = rotate([3, 4], 2 * Math.PI)
+      expect(result[0]).toBeCloseTo(3)
+      expect(result[1]).toBeCloseTo(4)
+    })
+  })
+
+  describe("rotateAround", () => {
+    it("rotates around origin (same as rotate)", () => {
+      const result = rotateAround([0, 0], [1, 0], Math.PI / 2)
+      expect(result[0]).toBeCloseTo(0)
+      expect(result[1]).toBeCloseTo(1)
+    })
+
+    it("rotates around center point", () => {
+      const result = rotateAround([0.5, 0.5], [1, 0.5], Math.PI)
+      expect(result[0]).toBeCloseTo(0)
+      expect(result[1]).toBeCloseTo(0.5)
+    })
+
+    it("rotates around arbitrary point", () => {
+      const result = rotateAround([1, 1], [2, 1], Math.PI / 2)
+      expect(result[0]).toBeCloseTo(1)
+      expect(result[1]).toBeCloseTo(2)
+    })
+
+    it("returns same point when rotating by 0", () => {
+      const result = rotateAround([0.5, 0.5], [1, 0.5], 0)
+      expect(result[0]).toBeCloseTo(1)
+      expect(result[1]).toBeCloseTo(0.5)
+    })
+  })
+
+  describe("normalize", () => {
+    it("normalizes a vector to unit length", () => {
+      const result = normalize([3, 4])
+      expect(result[0]).toBeCloseTo(0.6)
+      expect(result[1]).toBeCloseTo(0.8)
+      expect(magnitude(result)).toBeCloseTo(1)
+    })
+
+    it("normalizes unit vectors (no change)", () => {
+      const result = normalize([1, 0])
+      expect(result[0]).toBeCloseTo(1)
+      expect(result[1]).toBeCloseTo(0)
+    })
+
+    it("normalizes negative vectors", () => {
+      const result = normalize([-3, -4])
+      expect(result[0]).toBeCloseTo(-0.6)
+      expect(result[1]).toBeCloseTo(-0.8)
+      expect(magnitude(result)).toBeCloseTo(1)
+    })
+  })
+
+  describe("scale", () => {
+    it("scales a vector by a factor", () => {
+      expect(scale([2, 3], 2)).toEqual([4, 6])
+    })
+
+    it("scales by 1 (no change)", () => {
+      expect(scale([5, 7], 1)).toEqual([5, 7])
+    })
+
+    it("scales by 0", () => {
+      expect(scale([5, 7], 0)).toEqual([0, 0])
+    })
+
+    it("scales by negative factor", () => {
+      expect(scale([2, 3], -1)).toEqual([-2, -3])
+    })
+
+    it("scales by fractional factor", () => {
+      expect(scale([10, 20], 0.5)).toEqual([5, 10])
+    })
+  })
+
+  describe("polarToCartesian", () => {
+    it("converts at 0 angle", () => {
+      const result = polarToCartesian([0.5, 0.5], 0.2, 0)
+      expect(result[0]).toBeCloseTo(0.7)
+      expect(result[1]).toBeCloseTo(0.5)
+    })
+
+    it("converts at 90 degrees", () => {
+      const result = polarToCartesian([0.5, 0.5], 0.2, Math.PI / 2)
+      expect(result[0]).toBeCloseTo(0.5)
+      expect(result[1]).toBeCloseTo(0.7)
+    })
+
+    it("converts at 180 degrees", () => {
+      const result = polarToCartesian([0.5, 0.5], 0.2, Math.PI)
+      expect(result[0]).toBeCloseTo(0.3)
+      expect(result[1]).toBeCloseTo(0.5)
+    })
+
+    it("converts at 270 degrees", () => {
+      const result = polarToCartesian([0.5, 0.5], 0.2, (3 * Math.PI) / 2)
+      expect(result[0]).toBeCloseTo(0.5)
+      expect(result[1]).toBeCloseTo(0.3)
+    })
+
+    it("handles zero radius", () => {
+      const result = polarToCartesian([0.5, 0.5], 0, Math.PI / 4)
+      expect(result[0]).toBeCloseTo(0.5)
+      expect(result[1]).toBeCloseTo(0.5)
+    })
+  })
+
+  describe("pointAlong", () => {
+    it("finds midpoint", () => {
+      expect(pointAlong([0, 0], [10, 10], 0.5)).toEqual([5, 5])
+    })
+
+    it("returns start point at 0", () => {
+      expect(pointAlong([0, 0], [10, 10], 0)).toEqual([0, 0])
+    })
+
+    it("returns end point at 1", () => {
+      expect(pointAlong([0, 0], [10, 10], 1)).toEqual([10, 10])
+    })
+
+    it("finds quarter point", () => {
+      expect(pointAlong([0, 0], [10, 10], 0.25)).toEqual([2.5, 2.5])
+    })
+
+    it("handles negative coordinates", () => {
+      expect(pointAlong([-5, -5], [5, 5], 0.5)).toEqual([0, 0])
+    })
+
+    it("uses default proportion of 0.5", () => {
+      expect(pointAlong([0, 0], [10, 10])).toEqual([5, 5])
+    })
+
+    it("extrapolates beyond end point", () => {
+      expect(pointAlong([0, 0], [10, 10], 2)).toEqual([20, 20])
+    })
+  })
+
+  describe("dot", () => {
+    it("calculates dot product of two vectors", () => {
+      expect(dot([1, 2], [3, 4])).toBe(11) // 1*3 + 2*4 = 11
+    })
+
+    it("returns 0 for perpendicular vectors", () => {
+      expect(dot([1, 0], [0, 1])).toBe(0)
+    })
+
+    it("calculates square of magnitude for same vector", () => {
+      expect(dot([3, 4], [3, 4])).toBe(25) // magnitude squared
+    })
+
+    it("handles zero vector", () => {
+      expect(dot([0, 0], [5, 5])).toBe(0)
+    })
+
+    it("handles negative values", () => {
+      expect(dot([1, -2], [-3, 4])).toBe(-11) // 1*(-3) + (-2)*4 = -11
+    })
+  })
+})


### PR DESCRIPTION
Significantly improve test coverage from ~12 tests to 213 tests across all core library modules:

- vectors.ts: 50 tests for all vector operations (add, subtract, rotate, normalize, etc.)
- colors.ts: 19 tests for HSLA conversion and color gradient functions
- gradient.ts: 10 tests for LinearGradient and RadialGradient classes
- paths (Circle, Rect, SimplePath): 38 tests for shape creation, manipulation, and transformations
- collectionOps.ts: 26 tests including new tests for zip2, sum, and arrayOf
- noise.ts: 10 tests for perlin2 noise function
- palette.ts: 12 tests for palette generation and presets
- sCanvas.ts: 40 tests for the main SCanvas API including iteration, randomness, and transformations

https://claude.ai/code/session_01H1NQn57F7z8akCvndA8JaM